### PR TITLE
ci: block tag builds when tag != VERSION-DOCKERREVISION

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,31 @@ on:
       - 'v*'
 
 jobs:
+  # Gate for version tags: the images and the Helm chart are versioned from
+  # VERSION-DOCKERREVISION below, NOT from the git tag name. Refuse to run the
+  # whole pipeline if a pushed tag `vX.Y.Z-N` does not match that env, so a
+  # release tag can never disagree with what is actually built and published.
+  # The job always runs (only the check step is tag-gated), so branch builds
+  # pass it as a no-op; `test` depends on it, and every other job depends on
+  # `test`, so a mismatch blocks everything.
+  check-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag must equal v${VERSION}-${DOCKERREVISION}
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          expected="${VERSION}-${DOCKERREVISION}"
+          got="${GITHUB_REF_NAME#v}"
+          if [ "$got" != "$expected" ]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' does not match VERSION-DOCKERREVISION." \
+                 "Expected 'v${expected}'. Update env in" \
+                 ".github/workflows/docker-publish.yml (VERSION / DOCKERREVISION) or retag."
+            exit 1
+          fi
+          echo "Tag '${GITHUB_REF_NAME}' matches VERSION-DOCKERREVISION (${expected})."
+
   test:
+    needs: check-tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

Adds a `check-tag` gate job to `.github/workflows/docker-publish.yml`.

On a version tag (`v*`), it fails the run unless the tag matches
`VERSION-DOCKERREVISION` from the workflow env — e.g. with `VERSION: 2.23.0`
and `DOCKERREVISION: 2`, only `v2.23.0-2` is allowed.

## Why

Both the Docker image tags (via `docker-common`) and the Helm chart (via the
`publish-helm` job) are versioned from `VERSION-DOCKERREVISION`, **not** from the
git tag name. A tag whose name disagrees with that env would build/publish
under a different version than the tag implies (or, before the env-based Helm
fix, reference images that don't exist). This gate makes such a mismatch fail
fast instead of producing a misleading release.

## How

- `check-tag` always runs, but the check step is guarded by
  `if: startsWith(github.ref, 'refs/tags/')` → it's a no-op success on branch
  pushes.
- `test` now `needs: check-tag`, and every other job transitively depends on
  `test`, so a mismatch blocks the entire pipeline (build + publish-helm).

## Behaviour

| Env | Tag | Result |
|-----|-----|--------|
| 2.23.0 / 2 | `v2.23.0-2` | ✅ runs |
| 2.23.0 / 2 | `v2.23.0-3` | ❌ blocked |
| any | branch push | ✅ no-op |

To release: bump `VERSION`/`DOCKERREVISION` and tag `v<VERSION>-<DOCKERREVISION>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tag-format validation to the release workflow to ensure version tags follow the expected `vX.Y.Z-REVISION` pattern.
  * Prevented downstream release steps from running when a pushed tag does not match the required format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->