### PR TITLE
ci(pr): skip build-all for non-image changes + auto-cancel runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,21 @@ name: Build and test Docker Images
 on:
   push:
     branches-ignore: [master,stable,experimental]
+    # The full ./build-all (every image, one runner) is heavy. Skip it for
+    # changes that don't affect the images — Helm chart, CI workflows, docs —
+    # so CI-only branches don't spend ~an hour building nothing relevant.
+    paths-ignore:
+      - 'helm/**'
+      - '.github/**'
+      - '**.md'
+      - LICENSE
+      - cleanup-old-tags.sh
+
+# Cancel a previous run still building when a new commit is pushed to the same
+# branch, instead of letting runs pile up.
+concurrency:
+  group: pr-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
`pr.yml` runs `./build-all` (every image, single runner) on **every** branch
push — slow, and it gets cancelled (see the red `test` on recent CI-only PRs
like #17, whose change never touched an image).

Two changes, `pr.yml` only:

- **`paths-ignore`**: don't run `build-all` when a push only touches
  `helm/**`, `.github/**`, `**.md`, `LICENSE` or `cleanup-old-tags.sh`.
  Uses an *ignore* list (not an allowlist) so any real image path still triggers.
- **`concurrency` + `cancel-in-progress`**: a new push cancels the previous
  in-flight run on the same branch instead of stacking them.

Note: if `test` is a *required* status check, a skipped run leaves it pending;
you may want to make it non-required (or a required check that reports success
when skipped). Scope: master only, as requested.