### PR TITLE
ci(lts-2.21): update docker actions + trivy to current majors

### DIFF
--- a/.github/actions/docker-common/action.yml
+++ b/.github/actions/docker-common/action.yml
@@ -38,11 +38,11 @@ runs:
         shell: bash
         run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ inputs.DOCKER_USERNAME }}
           password: ${{ inputs.DOCKER_PASSWORD }}
@@ -68,7 +68,7 @@ runs:
           fi
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.DOCKER_IMAGE }}
       - name: Generate tags
@@ -112,7 +112,7 @@ runs:
             echo "tag=${{ steps.date.outputs.date }}${{ inputs.IMAGE_SUFFIX }}-lts" >> $GITHUB_OUTPUT
           fi
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.DIRNAME }}
           build-args: |
@@ -133,7 +133,7 @@ runs:
           fi
       - name: Build and publish non-root image
         if: inputs.NON_ROOT == 'yes'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: no-root
           build-args: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           docker build -t docker.io/my-organization/my-app:${{ github.sha }} --build-arg=BASE=yadd/lemonldap-ng-base:latest-no-s6 ./portal
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
           format: 'template'


### PR DESCRIPTION
Updates the remaining outdated actions (the `docker/*` composite + trivy).

| Action | After |
|--------|-------|
| `docker/setup-qemu-action` | **v4** |
| `docker/setup-buildx-action` | **v4** |
| `docker/login-action` | **v4** |
| `docker/metadata-action` | **v6** |
| `docker/build-push-action` | **v7** |
| `aquasecurity/trivy-action` | **v0.36.0** |

Left as-is on purpose: `hadolint/hadolint-action` (pinned by commit SHA — good
practice) and `christian-korneck/update-container-description-action@v1` (already
the current major).

⚠️ **Behaviour note — `build-push-action@v7`**: since v5, build attestations
(provenance/SBOM) are added by default when pushing, which appends an extra
attestation entry to the image index on Docker Hub. If you want the previous
behaviour (no attestation manifest), add `provenance: false` to the
`build-push-action` steps in `.github/actions/docker-common/action.yml`. Say the
word and I add it.